### PR TITLE
Potential wrong evaluation of A and B or C or not(D).

### DIFF
--- a/exprtk_simple_example_07.cpp
+++ b/exprtk_simple_example_07.cpp
@@ -25,12 +25,13 @@ template <typename T>
 void logic()
 {
    typedef exprtk::expression<T> expression_t;
-   std::string expression_string = "not(A and B) or C";
+   std::string expression_string = "A and B or C or not(D)";
 
    exprtk::symbol_table<T> symbol_table;
    symbol_table.create_variable("A");
    symbol_table.create_variable("B");
    symbol_table.create_variable("C");
+   symbol_table.create_variable("D");
 
    expression_t expression;
    expression.register_symbol_table(symbol_table);
@@ -38,24 +39,26 @@ void logic()
    exprtk::parser<T> parser;
    parser.compile(expression_string,expression);
 
-   printf(" # | A | B | C | %s\n"
-          "---+---+---+---+-%s\n",
+   printf(" #  | A | B | C | D | %s\n"
+          "----+---+---+---+---+ %s\n",
           expression_string.c_str(),
           std::string(expression_string.size(),'-').c_str());
 
-   for (int i = 0; i < 8; ++i)
+   for (int i = 0; i < 16; ++i)
    {
       symbol_table.get_variable("A")->ref() = T(i & 0x01 ? 1 : 0);
       symbol_table.get_variable("B")->ref() = T(i & 0x02 ? 1 : 0);
       symbol_table.get_variable("C")->ref() = T(i & 0x04 ? 1 : 0);
+      symbol_table.get_variable("D")->ref() = T(i & 0x08 ? 1 : 0);
 
       int result = static_cast<int>(expression.value());
 
-      printf(" %d | %d | %d | %d | %d \n",
+      printf(" %2d | %d | %d | %d | %d | %d\n",
              i,
              static_cast<int>(symbol_table.get_variable("A")->value()),
              static_cast<int>(symbol_table.get_variable("B")->value()),
              static_cast<int>(symbol_table.get_variable("C")->value()),
+             static_cast<int>(symbol_table.get_variable("D")->value()),
              result);
    }
 }


### PR DESCRIPTION
It seems exprtk evaluates the expression ```A and B or C or not(D)``` wrong.

The output of the modified example is as follows:
```
 #  | A | B | C | D | A and B or C or not(D)
----+---+---+---+---+ ----------------------
  0 | 0 | 0 | 0 | 0 | 0
  1 | 1 | 0 | 0 | 0 | 1
  2 | 0 | 1 | 0 | 0 | 0
  3 | 1 | 1 | 0 | 0 | 1
  4 | 0 | 0 | 1 | 0 | 0
  5 | 1 | 0 | 1 | 0 | 1
  6 | 0 | 1 | 1 | 0 | 0
  7 | 1 | 1 | 1 | 0 | 1
  8 | 0 | 0 | 0 | 1 | 0
  9 | 1 | 0 | 0 | 1 | 0
 10 | 0 | 1 | 0 | 1 | 0
 11 | 1 | 1 | 0 | 1 | 1
 12 | 0 | 0 | 1 | 1 | 0
 13 | 1 | 0 | 1 | 1 | 1
 14 | 0 | 1 | 1 | 1 | 0
 15 | 1 | 1 | 1 | 1 | 1
```
which is obviously wrong. 
In addition, to my own calculation i verified my result with wolfram alpha: http://www.wolframalpha.com/input/?i=A+and+B+or+C+or+not+D++++++truth+table, which demonstrates that exprtk is wrong.

In case this wrong behavior is caused by me, using exprtk the wrong way, please give me a hint.

Many thanks

Martin Ettl
  