### PR TITLE
Fix build error with Ubuntu precise's version of GCC with C++0X enabled

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -5452,7 +5452,7 @@ namespace exprtk
          : value_(v)
          {
             rp_.n0_c = std::make_pair<bool,std::size_t>(true,0);
-            rp_.n1_c = std::make_pair<bool,std::size_t>(true,v.size() - 1);
+            rp_.n1_c = std::make_pair(true, size_t(v.size() - 1));
             rp_.cache.first  = rp_.n0_c.second;
             rp_.cache.second = rp_.n1_c.second;
          }
@@ -7361,7 +7361,7 @@ namespace exprtk
          : value_(&v)
          {
             rp_.n0_c = std::make_pair<bool,std::size_t>(true,0);
-            rp_.n1_c = std::make_pair<bool,std::size_t>(true,v.size() - 1);
+            rp_.n1_c = std::make_pair(true, size_t(v.size() - 1));
             rp_.cache.first  = rp_.n0_c.second;
             rp_.cache.second = rp_.n1_c.second;
          }


### PR DESCRIPTION
This patch has been tested to build on: 
* MSVC 2015
* GCC (versions from Ubuntu Precise to Yaketty)
* CLANG under GNU/Linux
* CLANG under OSX

(cc: discussion in https://github.com/MRPT/mrpt/commit/04c24b6e2e3b2ac6372d4ca278adb7f7b1132163#commitcomment-19874974)

Forcing `make_pair<>` via explicit arguments leads the compiler to try
to match it against the version with universal references (T&&), failing
because the compiler does not want to match "v.size()-1" to it.

Error example:

/<<PKGBUILDDIR>>.../exprtk.hpp:5455:74: error: no matching function for
call to ‘make_pair(bool, std::basic_string<char>::size_type&)’
/<<PKGBUILDDIR>>.../exprtk.hpp:5455:74: note: candidate is:
/usr/include/c++/4.6/bits/stl_pair.h:262:5: note: template<class _T1,
class _T2> std::pair<typename std::__decay_and_strip<_T1>::__type,
typename std::__decay_and_strip<_T2>::__type> std::make_pair(_T1&&,
_T2&&)
/<<PKGBUILDDIR>>.../exprtk.hpp: In constructor
‘exprtk::details::stringvar_node<T>::stringvar_node(std::string&)’:
/<<PKGBUILDDIR>>.../exprtk.hpp:7364:74: error: no matching function for
call to ‘make_pair(bool, std::basic_string<char>::size_type&)’
/<<PKGBUILDDIR>>/libs/base/include/mrpt/otherlibs/exprtk.hpp:7364:74:
note: candidate is:
/usr/include/c++/4.6/bits/stl_pair.h:262:5: note: template<class _T1,
class _T2> std::pair<typename std::__decay_and_strip<_T1>::__type,
typename std::__decay_and_strip<_T2>::__type> std::make_pair(_T1&&,
_T2&&)
/usr/bin/cmake -E cmake_progress_report
"/<<PKGBUILDDIR>>/obj-arm-linux-gnueabihf/CMakeFiles"