### PR TITLE
BUG: fix a bug for clang.

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -1962,7 +1962,7 @@ namespace exprtk
       template <typename T>
       inline bool string_to_real(const std::string& s, T& t)
       {
-         const typename numeric::details::number_type<T>::type num_type;
+         typename numeric::details::number_type<T>::type num_type;
 
          const char_t* begin = s.data();
          const char_t* end   = s.data() + s.size();


### PR DESCRIPTION
There is a bug when building exprtk with clang. 

Const type  without a user-provided default constructor.
https://stackoverflow.com/questions/26077807/why-does-gcc-allow-a-const-object-without-a-user-declared-default-constructor-bu