### PR TITLE
Fix undefined macro _MSC_VER Wundef warning on Linux/clang 5.0

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -2780,7 +2780,7 @@ namespace exprtk
                         Note: The following 'awkward' conditional is
                               due to various broken msvc compilers.
                      */
-                     #if _MSC_VER == 1600
+                     #if defined(_MSC_VER) && (_MSC_VER == 1600)
                      const bool within_range = !is_end(s_itr_ + 2) &&
                                                !is_end(s_itr_ + 3) ;
                      #else


### PR DESCRIPTION
I confirm its clang:

```
$ clang++ --version
clang version 5.0.1 (tags/RELEASE_501/final)
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/sbin

$ cd /tmp && git clone https://github.com/ArashPartow/exprtk.git && cd exprtk && clang++ -Wundef exprtk_simple_example_01.cpp
Cloning into 'exprtk'...
In file included from exprtk_simple_example_01.cpp:22:
./exprtk.hpp:2783:26: warning: '_MSC_VER' is not defined, evaluates to 0 [-Wundef]
                     #if _MSC_VER == 1600
                         ^
1 warning generated.
```