### PR TITLE
Equality operator on symbol_table should be const

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -16732,7 +16732,7 @@ namespace exprtk
          return (*this);
       }
 
-      inline bool operator==(const symbol_table<T>& st)
+      inline bool operator==(const symbol_table<T>& st) const
       {
          return (this == &st) || (control_block_ == st.control_block_);
       }


### PR DESCRIPTION
The `exprtk::symbol_table<T>::operator ==` was not marked as const, causing problems in my particular way of using the library. This pull request fixes that.