### PR TITLE
Eliminate the need for bool operator>(unsigned long x1, const T x2)

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -24489,7 +24489,7 @@ namespace exprtk
                }
             }
 
-            if (vec_initilizer_list.size() > vector_size)
+            if (T(vec_initilizer_list.size()) > vector_size)
             {
                set_error(
                   make_error(parser_error::e_syntax,


### PR DESCRIPTION
This comparison operator was required in only one place.
Change this place to use operator> between T and T instead, like in most other places.