### PR TITLE
Fix compilation error: assignment of read-only member

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -24403,9 +24403,9 @@ namespace exprtk
             parse_function_prototypes(func_prototypes);
          }
 
-         void set_default_return_type(const std::string& return_type)
+         void set_default_return_type(const return_type_t return_type)
          {
-            default_return_type_ = return_type;
+            const_cast<return_type_t&>(default_return_type_) = return_type;
          }
 
          bool verify(const std::string& param_seq, std::size_t& pseq_index)


### PR DESCRIPTION
I was getting this compilation error, and that code line didn't quite make sense, since the expression on the left is const and is of different type:
```
error: assignment of read-only member ‘exprtk::parser<double>::type_checker::default_return_type_’
[build] 24408 |             default_return_type_ = return_type;
[build]       |             ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
```