### PR TITLE
Fix compilation error: no matching function for call

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -17368,12 +17368,13 @@ namespace exprtk
             {
                struct deleter
                {
-                  static inline void process(std::pair<bool,variable_node_t*>& n)  { delete n.second; }
-                  static inline void process(std::pair<bool,vector_t*>& n)         { delete n.second; }
+                  static inline void process(std::pair<bool,variable_node_t*>&    n) { delete n.second; }
+                  static inline void process(std::pair<bool,ivararg_function_t*>& n) { delete n.second; }
+                  static inline void process(std::pair<bool,vector_t*>& n)           { delete n.second; }
                   #ifndef exprtk_disable_string_capabilities
-                  static inline void process(std::pair<bool,stringvar_node_t*>& n) { delete n.second; }
+                  static inline void process(std::pair<bool,stringvar_node_t*>&   n) { delete n.second; }
                   #endif
-                  static inline void process(std::pair<bool,function_t*>&)         {                  }
+                  static inline void process(std::pair<bool,function_t*>&)           {                  }
                };
 
                if (delete_node)


### PR DESCRIPTION
```
exprtk.hpp:17381:35: error: no matching function for call to ‘exprtk::symbol_table<T>::type_store<Type, RawType>::remove<exprtk::ivararg_function<double>, exprtk::ivararg_function<double> >::deleter::process(std::pair<bool, exprtk::ivararg_function<double>*>&)’
[build] 17381 |                   deleter::process((*itr).second);
[build]       |                   ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
[build] exprtk.hpp:17371:38: note: candidate: ‘static void exprtk::symbol_table<T>::type_store<Type, RawType>::remove(const string&, bool)::deleter::process(std::pair<bool, exprtk::details::variable_node<T>*>&) [with Type = exprtk::ivararg_function<double>; RawType = exprtk::ivararg_function<double>; T = double]’
[build] 17371 |                   static inline void process(std::pair<bool,variable_node_t*>& n)  { delete n.second; }
```