### PR TITLE
Fix error: unused parameter ‘itr’

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -2415,7 +2415,11 @@ namespace exprtk
             return (s_end_ == itr);
          }
 
-         inline bool is_comment_start(details::char_cptr itr)
+         inline bool is_comment_start(details::char_cptr
+            #ifdef exprtk_disable_comments
+            itr
+            #endif
+         )
          {
             #ifndef exprtk_disable_comments
             const char_t c0 = *(itr + 0);


### PR DESCRIPTION
```
exprtk.hpp:2418:58: error: unused parameter ‘itr’ [-Werror=unused-parameter]
 2418 |          inline bool is_comment_start(details::char_cptr itr)
      |                                       ~~~~~~~~~~~~~~~~~~~^~~
```