### PR TITLE
Fix handling of UTF-8 characters in string constants

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -175,7 +175,7 @@ namespace exprtk
 
       inline bool is_valid_string_char(const char_t c)
       {
-         return std::isprint(static_cast<uchar_t>(c)) ||
+         return !std::iscntrl(static_cast<uchar_t>(c)) ||
                 is_whitespace(c);
       }
 


### PR DESCRIPTION
Exprtk does not correctly handle string constants containing UTF-8 characters . For example, the following expression is rejected with an "ERR004 - Invalid string token" error:
**city='Zürich'**

The enclosed patch fixes this problem.