### PR TITLE
Disable fallthrough warnings for clang compiler

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -77,6 +77,15 @@ namespace exprtk
       #define exprtk_disable_fallthrough_end                        \
       _Pragma ("GCC diagnostic pop")                                \
 
+   #elif defined(__clang__)
+
+      #define exprtk_disable_fallthrough_begin                        \
+      _Pragma ("clang diagnostic push")                               \
+      _Pragma ("clang diagnostic ignored \"-Wimplicit-fallthrough\"") \
+
+      #define exprtk_disable_fallthrough_end                          \
+      _Pragma ("clang diagnostic pop")                                \
+
    #else
       #define exprtk_disable_fallthrough_begin (void)0;
       #define exprtk_disable_fallthrough_end   (void)0;


### PR DESCRIPTION
When compiling an application that includes `exprtk.hpp` using Clang (Version `Apple clang version 12.0.5 (clang-1205.0.22.9)` tested using Mac) with the flags `-Wimplicit-fallthrough -Werror` our compile fails because of the implicit fallthroughs. I suppose the same should happen under Linux when compiling with Clang.

This patch applies the same ignore mechanism that is used for GCC for Clang.

I've tested to work the change on the following Plattforms:
- Intel MacOS: Apple clang version 12.0.5 (clang-1205.0.22.9)
- M1 MacOS: clang version 14.0.0 (clang-1400.0.29.102)
- amd64 Debian: g++ 12.2.0
- amd64 Debian: clang 9.0.1-20+b1
- amd64 Debian: clang 11.1.0-6+b2
- amd64 Debian: clang 13.0.1-7
- amd64 Debian: clang 14.0.6-2