### PR TITLE
Safe vector access

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -4471,7 +4471,7 @@ namespace exprtk
          }
 #ifdef exprtk_enable_vector_runtime_checks
          inline void set(std::size_t i, value_t value)
-      	 {
+         {
              if (i < size())
              {
                  data_[i] = value;
@@ -7598,7 +7598,7 @@ namespace exprtk
          }
 #endif
 
-      	 inline const T& ref() const exprtk_override
+         inline const T& ref() const exprtk_override
          {
             return (*value_);
          }
@@ -7904,7 +7904,7 @@ namespace exprtk
               return T(0);
              #else
               return *(vector_base_ + static_cast<std::size_t>(details::numeric::to_int64(index_.first->value())));
-             #endif            
+             #endif
          }
 
          #ifdef exprtk_enable_vector_runtime_checks
@@ -8077,7 +8077,7 @@ namespace exprtk
          {
              return *(vds_.data() + index_);
          }
-         #endif         
+         #endif
 
          inline const T& ref() const exprtk_override
          {
@@ -8189,15 +8189,15 @@ namespace exprtk
 
          inline T value() const exprtk_override
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            const T tmp = var1_->ref();
-            var1_->set(var0_->ref());
-            var0_->set(tmp);
-            return tmp;
-#else
-            std::swap(var0_->ref(),var1_->ref());
-            return var1_->ref();
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             const T tmp = var1_->ref();
+             var1_->set(var0_->ref());
+             var0_->set(tmp);
+             return tmp;
+            #else
+             std::swap(var0_->ref(),var1_->ref());
+             return var1_->ref();
+            #endif
          }
 
          inline typename expression_node<T>::node_type type() const exprtk_override
@@ -10471,13 +10471,13 @@ namespace exprtk
             if (var_node_ptr_)
             {
                assert(branch(1));
-#ifdef exprtk_enable_vector_runtime_checks
-               T result = branch(1)->value();
-               var_node_ptr_->set(result);
-#else
-               T& result = var_node_ptr_->ref();
-               result = branch(1)->value();
-#endif
+               #ifdef exprtk_enable_vector_runtime_checks
+                T result = branch(1)->value();
+                var_node_ptr_->set(result);
+               #else
+                T& result = var_node_ptr_->ref();
+                result = branch(1)->value();
+               #endif
 
                return result;
             }
@@ -10558,13 +10558,13 @@ namespace exprtk
             if (rbvec_node_ptr_)
             {
                assert(branch(1));
-#ifdef exprtk_enable_vector_runtime_checks
-               T result = branch(1)->value();
-               rbvec_node_ptr_->set(result);
-#else
-               T& result = rbvec_node_ptr_->ref();
-                  result = branch(1)->value();
-#endif               
+               #ifdef exprtk_enable_vector_runtime_checks
+                T result = branch(1)->value();
+                rbvec_node_ptr_->set(result);
+               #else
+                T& result = rbvec_node_ptr_->ref();
+                   result = branch(1)->value();
+               #endif
                return result;
             }
             else
@@ -10601,15 +10601,15 @@ namespace exprtk
             if (rbvec_node_ptr_)
             {
                assert(branch(1));
-#ifdef exprtk_enable_vector_runtime_checks
-               T val = branch(1)->value();
-               rbvec_node_ptr_->set(val);
-               return val;
-#else
-               T& result = rbvec_node_ptr_->ref();
-               result = branch(1)->value();
-               return result;
-#endif
+               #ifdef exprtk_enable_vector_runtime_checks
+                T val = branch(1)->value();
+                rbvec_node_ptr_->set(val);
+                return val;
+               #else
+                T& result = rbvec_node_ptr_->ref();
+                result = branch(1)->value();
+                return result;
+               #endif
             }
             else
                return std::numeric_limits<T>::quiet_NaN();
@@ -12759,7 +12759,11 @@ namespace exprtk
                      return false;
 
                   ts.size = 1;
+#ifdef exprtk_enable_vector_runtime_checks
                   ts.data = var->value_ptr();
+#else
+                  ts.data = &var->ref();
+#endif
                   ts.type = type_store_t::e_scalar;
                }
                else
@@ -37812,21 +37816,21 @@ namespace exprtk
 
       if (var)
       {
-#ifdef exprtk_enable_vector_runtime_checks
+         #ifdef exprtk_enable_vector_runtime_checks
           T& x = *(var->value_ptr());
           const T x_original = x;
           const T result = integrate(e, x, r0, r1, number_of_intervals);
           var->set(x_original);
 
           return result;
-#else
-         T& x = var->ref();
-         const T x_original = x;
-         const T result = integrate(e, x, r0, r1, number_of_intervals);
-         x = x_original;
+         #else
+          T& x = var->ref();
+          const T x_original = x;
+          const T result = integrate(e, x, r0, r1, number_of_intervals);
+          x = x_original;
 
-         return result;
-#endif
+          return result;
+         #endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -37912,21 +37916,21 @@ namespace exprtk
 
       if (var)
       {
-#ifdef exprtk_enable_vector_runtime_checks
-         T& x = *(var->value_ptr());
-         const T x_original = x;
-         const T result = derivative(e, x, h);
-         var->set(x_original);
+         #ifdef exprtk_enable_vector_runtime_checks
+          T& x = *(var->value_ptr());
+          const T x_original = x;
+          const T result = derivative(e, x, h);
+          var->set(x_original);
 
-         return result;
-#else
-      	 T& x = var->ref();
-         const T x_original = x;
-         const T result = derivative(e, x, h);
-         x = x_original;
+          return result;
+         #else
+          T& x = var->ref();
+          const T x_original = x;
+          const T result = derivative(e, x, h);
+          x = x_original;
 
-         return result;
-#endif
+          return result;
+         #endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -37948,21 +37952,21 @@ namespace exprtk
 
       if (var)
       {
-#ifdef exprtk_enable_vector_runtime_checks
-         T &x = *(var->value_ptr());
-         const T x_original = x;
-         const T result = second_derivative(e, x, h);
-         var->set(x_original);
+         #ifdef exprtk_enable_vector_runtime_checks
+          T &x = *(var->value_ptr());
+          const T x_original = x;
+          const T result = second_derivative(e, x, h);
+          var->set(x_original);
 
-         return result;
-#else         
-         T& x = var->ref();
-         const T x_original = x;
-         const T result = second_derivative(e, x, h);
-         x = x_original;
+          return result;
+         #else
+          T& x = var->ref();
+          const T x_original = x;
+          const T result = second_derivative(e, x, h);
+          x = x_original;
 
-         return result;
-#endif
+          return result;
+         #endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -37984,21 +37988,21 @@ namespace exprtk
 
       if (var)
       {
-#ifdef exprtk_enable_vector_runtime_checks
-         T &x = *(var->value_ptr());
-         const T x_original = x;
-         const T result = third_derivative(e, x, h);
-         var->set(x_original);
+         #ifdef exprtk_enable_vector_runtime_checks
+          T &x = *(var->value_ptr());
+          const T x_original = x;
+          const T result = third_derivative(e, x, h);
+          var->set(x_original);
 
-         return result;
-#else
-         T& x = var->ref();
-         const T x_original = x;
-         const T result = third_derivative(e, x, h);
-         x = x_original;
+          return result;
+         #else
+          T& x = var->ref();
+          const T x_original = x;
+          const T result = third_derivative(e, x, h);
+          x = x_original;
 
-         return result;
-#endif
+          return result;
+         #endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -40408,11 +40412,11 @@ namespace exprtk
 
          for (std::size_t i = r1 - n + 1; i <= r1; ++i)
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            vec.set(i, T(0));
-#else
-            vec[i] = T(0);
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             vec.set(i, T(0));
+            #else
+             vec[i] = T(0);
+            #endif
          }
 
          return T(1);
@@ -40472,11 +40476,11 @@ namespace exprtk
 
          for (std::size_t i = r0; i < r0 + n; ++i)
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            vec.set(i, T(0));
-#else
-            vec[i] = T(0);
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             vec.set(i, T(0));
+            #else
+             vec[i] = T(0);
+            #endif
          }
 
          return T(1);
@@ -40635,11 +40639,11 @@ namespace exprtk
 
             for (std::size_t i = r0; i <= r1; ++i, ++j)
             {
-#ifdef exprtk_enable_vector_runtime_checks
-               vec.set(i, base + (increment * j));
-#else
-               vec[i] = base + (increment * j);
-#endif
+               #ifdef exprtk_enable_vector_runtime_checks
+                vec.set(i, base + (increment * j));
+               #else
+                vec[i] = base + (increment * j);
+               #endif
             }
          }
 
@@ -40730,11 +40734,11 @@ namespace exprtk
 
          for (std::size_t i = r0; i <= r1; ++i)
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            y.set(i, (a * x[i]) + y[i]);
-#else
-            y[i] = (a * x[i]) + y[i];
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             y.set(i, (a * x[i]) + y[i]);
+            #else
+             y[i] = (a * x[i]) + y[i];
+            #endif
          }
 
          return T(1);
@@ -40782,11 +40786,11 @@ namespace exprtk
 
          for (std::size_t i = r0; i <= r1; ++i)
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            y.set(i, (a * x[i]) + (b * y[i]));
-#else
-            y[i] = (a * x[i]) + (b * y[i]);
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             y.set(i, (a * x[i]) + (b * y[i]));
+            #else
+             y[i] = (a * x[i]) + (b * y[i]);
+            #endif
          }
 
          return T(1);
@@ -40836,11 +40840,11 @@ namespace exprtk
 
          for (std::size_t i = r0; i <= r1; ++i)
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            z.set(i, (a * x[i]) + y[i]);
-#else
-            z[i] = (a * x[i]) + y[i];
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             z.set(i, (a * x[i]) + y[i]);
+            #else
+             z[i] = (a * x[i]) + y[i];
+            #endif
          }
 
          return T(1);
@@ -40891,11 +40895,11 @@ namespace exprtk
 
          for (std::size_t i = r0; i <= r1; ++i)
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            z.set(i, (a * x[i]) + (b * y[i]));
-#else
-            z[i] = (a * x[i]) + (b * y[i]);
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             z.set(i, (a * x[i]) + (b * y[i]));
+            #else
+             z[i] = (a * x[i]) + (b * y[i]);
+            #endif
          }
 
          return T(1);
@@ -40943,11 +40947,11 @@ namespace exprtk
 
          for (std::size_t i = r0; i <= r1; ++i)
          {
-#ifdef exprtk_enable_vector_runtime_checks
-            z.set(i, (a * x[i]) + b);
-#else
-            z[i] = (a * x[i]) + b;
-#endif
+            #ifdef exprtk_enable_vector_runtime_checks
+             z.set(i, (a * x[i]) + b);
+            #else
+             z[i] = (a * x[i]) + b;
+            #endif
          }
 
          return T(1);

--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -7586,11 +7586,17 @@ namespace exprtk
          {
              *value_ = val;
          }
-#endif
+
+         inline T* value_ptr()
+         {
+             return value_;
+         }
+#else
          inline T& ref() exprtk_override
          {
-            return (*value_);
+             return (*value_);
          }
+#endif
 
       	 inline const T& ref() const exprtk_override
          {
@@ -8183,8 +8189,15 @@ namespace exprtk
 
          inline T value() const exprtk_override
          {
+#ifdef exprtk_enable_vector_runtime_checks
+            const T tmp = var1_->ref();
+            var1_->set(var0_->ref());
+            var0_->set(tmp);
+            return tmp;
+#else
             std::swap(var0_->ref(),var1_->ref());
             return var1_->ref();
+#endif
          }
 
          inline typename expression_node<T>::node_type type() const exprtk_override
@@ -10458,9 +10471,13 @@ namespace exprtk
             if (var_node_ptr_)
             {
                assert(branch(1));
-
+#ifdef exprtk_enable_vector_runtime_checks
+               T result = branch(1)->value();
+               var_node_ptr_->set(result);
+#else
                T& result = var_node_ptr_->ref();
                result = branch(1)->value();
+#endif
 
                return result;
             }
@@ -12742,7 +12759,7 @@ namespace exprtk
                      return false;
 
                   ts.size = 1;
-                  ts.data = &var->ref();
+                  ts.data = var->value_ptr();
                   ts.type = type_store_t::e_scalar;
                }
                else
@@ -37795,12 +37812,21 @@ namespace exprtk
 
       if (var)
       {
+#ifdef exprtk_enable_vector_runtime_checks
+          T& x = *(var->value_ptr());
+          const T x_original = x;
+          const T result = integrate(e, x, r0, r1, number_of_intervals);
+          var->set(x_original);
+
+          return result;
+#else
          T& x = var->ref();
          const T x_original = x;
          const T result = integrate(e, x, r0, r1, number_of_intervals);
          x = x_original;
 
          return result;
+#endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -37886,12 +37912,21 @@ namespace exprtk
 
       if (var)
       {
-         T& x = var->ref();
+#ifdef exprtk_enable_vector_runtime_checks
+         T& x = *(var->value_ptr());
+         const T x_original = x;
+         const T result = derivative(e, x, h);
+         var->set(x_original);
+
+         return result;
+#else
+      	 T& x = var->ref();
          const T x_original = x;
          const T result = derivative(e, x, h);
          x = x_original;
 
          return result;
+#endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -37913,12 +37948,21 @@ namespace exprtk
 
       if (var)
       {
+#ifdef exprtk_enable_vector_runtime_checks
+         T &x = *(var->value_ptr());
+         const T x_original = x;
+         const T result = second_derivative(e, x, h);
+         var->set(x_original);
+
+         return result;
+#else         
          T& x = var->ref();
          const T x_original = x;
          const T result = second_derivative(e, x, h);
          x = x_original;
 
          return result;
+#endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -37940,12 +37984,21 @@ namespace exprtk
 
       if (var)
       {
+#ifdef exprtk_enable_vector_runtime_checks
+         T &x = *(var->value_ptr());
+         const T x_original = x;
+         const T result = third_derivative(e, x, h);
+         var->set(x_original);
+
+         return result;
+#else
          T& x = var->ref();
          const T x_original = x;
          const T result = third_derivative(e, x, h);
          x = x_original;
 
          return result;
+#endif
       }
       else
          return std::numeric_limits<T>::quiet_NaN();
@@ -40356,7 +40409,7 @@ namespace exprtk
          for (std::size_t i = r1 - n + 1; i <= r1; ++i)
          {
 #ifdef exprtk_enable_vector_runtime_checks
-             vec.set(i, T(0));
+            vec.set(i, T(0));
 #else
             vec[i] = T(0);
 #endif
@@ -40420,7 +40473,7 @@ namespace exprtk
          for (std::size_t i = r0; i < r0 + n; ++i)
          {
 #ifdef exprtk_enable_vector_runtime_checks
-             vec.set(i, T(0));
+            vec.set(i, T(0));
 #else
             vec[i] = T(0);
 #endif
@@ -40583,7 +40636,7 @@ namespace exprtk
             for (std::size_t i = r0; i <= r1; ++i, ++j)
             {
 #ifdef exprtk_enable_vector_runtime_checks
-                vec.set(i, base + (increment * j));
+               vec.set(i, base + (increment * j));
 #else
                vec[i] = base + (increment * j);
 #endif
@@ -40678,7 +40731,7 @@ namespace exprtk
          for (std::size_t i = r0; i <= r1; ++i)
          {
 #ifdef exprtk_enable_vector_runtime_checks
-             y.set(i, (a * x[i]) + y[i]);
+            y.set(i, (a * x[i]) + y[i]);
 #else
             y[i] = (a * x[i]) + y[i];
 #endif
@@ -40730,7 +40783,7 @@ namespace exprtk
          for (std::size_t i = r0; i <= r1; ++i)
          {
 #ifdef exprtk_enable_vector_runtime_checks
-             y.set(i, (a * x[i]) + (b * y[i]));
+            y.set(i, (a * x[i]) + (b * y[i]));
 #else
             y[i] = (a * x[i]) + (b * y[i]);
 #endif
@@ -40839,7 +40892,7 @@ namespace exprtk
          for (std::size_t i = r0; i <= r1; ++i)
          {
 #ifdef exprtk_enable_vector_runtime_checks
-             z.set(i, (a * x[i]) + (b * y[i]));
+            z.set(i, (a * x[i]) + (b * y[i]));
 #else
             z[i] = (a * x[i]) + (b * y[i]);
 #endif
@@ -40891,7 +40944,7 @@ namespace exprtk
          for (std::size_t i = r0; i <= r1; ++i)
          {
 #ifdef exprtk_enable_vector_runtime_checks
-             z.set(i, (a * x[i]) + b);
+            z.set(i, (a * x[i]) + b);
 #else
             z[i] = (a * x[i]) + b;
 #endif

--- a/exprtk_test.cpp
+++ b/exprtk_test.cpp
@@ -5988,7 +5988,11 @@ struct inc_func : public exprtk::igeneric_function<T>
 
                                              for (std::size_t x = 0; x < vector.size(); ++x)
                                              {
+#ifdef exprtk_enable_vector_runtime_checks
+                                                vector.set(x, vector[x] + T(1));
+#else
                                                 vector[x] += T(1);
+#endif
                                              }
                                           }
                                           break;
@@ -5998,7 +6002,11 @@ struct inc_func : public exprtk::igeneric_function<T>
 
                                              for (std::size_t x = 0; x < string.size(); ++x)
                                              {
+#ifdef exprtk_enable_vector_runtime_checks
+                                                string.set(x, string[x] + static_cast<typename string_t::value_t>(1));
+#else
                                                 string[x] += static_cast<typename string_t::value_t>(1);
+#endif
                                              }
                                           }
                                           break;


### PR DESCRIPTION
Our users are not always careful when accessing vectors either for reading or even more dangerous for writing values. Therefore, I would like to restrict the accesses to vectors to be within valid bounds.

Since this costs some time to check at runtime I enable this function by defining `exprtk_enable_vector_runtime_checks`.
When this define is not set, the old (unsecure) behavior is retained.

Runtime penalty:
![grafik](https://user-images.githubusercontent.com/764173/228276664-8455d31b-0ecf-4ed1-a7b5-884913a47c81.png)


Please let me know if I can improve things.
