### PR TITLE
Update exprtk.hpp

### DIFF
--- a/exprtk.hpp
+++ b/exprtk.hpp
@@ -14195,9 +14195,9 @@ namespace exprtk
 
             return (r[ 0] * r[ 1] * r[ 2] * r[ 3])
                    #ifndef exprtk_disable_superscalar_unroll
-                 + (r[ 4] * r[ 5] * r[ 6] * r[ 7])
-                 + (r[ 8] * r[ 9] * r[10] * r[11])
-                 + (r[12] * r[13] * r[14] * r[15])
+                 * (r[ 4] * r[ 5] * r[ 6] * r[ 7])
+                 * (r[ 8] * r[ 9] * r[10] * r[11])
+                 * (r[12] * r[13] * r[14] * r[15])
                    #endif
                    ;
          }


### PR DESCRIPTION
In struct vec_mul_op, process() results wrong value when the vec_size is greater than 16.